### PR TITLE
Task: Environments import restriction

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,7 @@
   "plugins": [
     ["module-resolver", {
       "alias": {
-        "environments": "./environments",
+        "^environments$": "./environments/index.js",
         "app": "./src/app"
       }
     }]

--- a/environments/variables/development.js
+++ b/environments/variables/development.js
@@ -1,5 +1,5 @@
-import { environments } from 'environments';
-import { pageConfig, packageJson } from 'environments/webpack/settings';
+import { environments } from '../';
+import { pageConfig, packageJson } from '../webpack/settings';
 
 export const env = {
   ENVIRONMENT: environments.dev,

--- a/environments/variables/local.js
+++ b/environments/variables/local.js
@@ -1,5 +1,5 @@
-import { environments } from 'environments';
-import { pageConfig, packageJson } from 'environments/webpack/settings';
+import { environments } from '../';
+import { pageConfig, packageJson } from '../webpack/settings';
 
 export const env = {
   ENVIRONMENT: environments.local,

--- a/environments/variables/production.js
+++ b/environments/variables/production.js
@@ -1,5 +1,5 @@
-import { environments } from 'environments';
-import { pageConfig, packageJson } from 'environments/webpack/settings';
+import { environments } from '../';
+import { pageConfig, packageJson } from '../webpack/settings';
 
 export const env = {
   ENVIRONMENT: environments.prod,

--- a/environments/variables/test.js
+++ b/environments/variables/test.js
@@ -1,4 +1,4 @@
-import { packageJson } from 'environments/webpack/settings';
+import { packageJson } from '../webpack/settings';
 
 export const env = {
   ENVIRONMENT: 'test',

--- a/environments/webpack/dev.config.js
+++ b/environments/webpack/dev.config.js
@@ -1,9 +1,8 @@
 import FaviconsWebpackPlugin from 'favicons-webpack-plugin';
 import ExtendedDefinePlugin from 'extended-define-webpack-plugin';
 
-import { environments } from 'environments';
-import { getVariables } from 'environments/variables';
-
+import { environments } from '../';
+import { getVariables } from '../variables';
 import { favicon } from './settings';
 import { baseConfig } from './base.config';
 

--- a/environments/webpack/local.config.js
+++ b/environments/webpack/local.config.js
@@ -2,9 +2,8 @@ import ExtendedDefinePlugin from 'extended-define-webpack-plugin';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import LiveReloadPlugin from 'webpack-livereload-plugin';
 
-import { environments } from 'environments';
-import { getVariables } from 'environments/variables';
-
+import { environments } from '../';
+import { getVariables } from '../variables';
 import { baseConfig } from './base.config';
 
 export const config = {

--- a/environments/webpack/prod.config.js
+++ b/environments/webpack/prod.config.js
@@ -3,9 +3,8 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import FaviconsWebpackPlugin from 'favicons-webpack-plugin';
 import ExtendedDefinePlugin from 'extended-define-webpack-plugin';
 
-import { environments } from 'environments';
-import { getVariables } from 'environments/variables';
-
+import { environments } from '../';
+import { getVariables } from '../variables';
 import { rules, page, favicon } from './settings';
 import { baseConfig } from './base.config';
 


### PR DESCRIPTION
**This PR** (unstrike the appropriate bullet points)**:**
  - ~fixes a bug~
  - ~introduces a feature or flavor~
  - improves current implementation

**I have:**
  - [x] linted the code
  - [x] tested the code
  - [x] read the [standards](STANDARDS.md), [contributing](CONTRIBUTING.md) and [code of conduct](CODE_OF_CONDUCT.md) guidelines

**Description and comments**
Restricted the import of environments on the application as the variables to be accessed during app compile/runtime should be already accessible through `extended-define-webpack-plugin`.
