### PR TITLE
Bugfix: Clean plugin path

### DIFF
--- a/config/base.config.js
+++ b/config/base.config.js
@@ -35,7 +35,7 @@ export const baseConfig = {
     } : {}),
   },
   plugins: [
-    new CleanWebpackPlugin(paths.distRelative, paths.baseAbsolute),
+    new CleanWebpackPlugin(paths.distRelative, { root: paths.baseAbsolute }),
     new CopyWebpackPlugin([{
       from: paths.staticAbsolute,
       to: paths.distAbsolute,

--- a/config/settings/paths.js
+++ b/config/settings/paths.js
@@ -1,6 +1,7 @@
 import { resolve } from 'path';
 
-const cleanPath = path => path.split('\\').filter(str => !!str).join('/');
+const cleanPathBase = slash => path => path.split(slash).filter(str => !!str).join('/');
+const cleanPath = path => cleanPathBase('/')(cleanPathBase('\\')(path));
 
 const pathsBase = './';
 const distBase = `${pathsBase}public/`;


### PR DESCRIPTION
**This PR** (unstrike the appropriate bullet points)**:**
  - fixes a bug
  - ~introduces a feature or flavor~
  - ~improves current implementation~

**I have:**
  - [x] linted the code
  - [x] tested the code
  - [x] read the [standards](../blob/develop/.github/STANDARDS.md), [contributing](../blob/develop/.github/CONTRIBUTING.md) and [code of conduct](../blob/develop/.github/CODE_OF_CONDUCT.md) guidelines

**Description and comments**
Fixed a bug where `clean-webpack-plugin` was skipping `public` folder.
